### PR TITLE
feat: 支持 CMS143 登录 + 特殊模式复选框控制凭据面板显隐

### DIFF
--- a/Aries/Aries.Lib/Aries.Lib.csproj
+++ b/Aries/Aries.Lib/Aries.Lib.csproj
@@ -73,9 +73,11 @@
     <Compile Include="EncryptUtil.cs" />
     <Compile Include="FileUtil.cs" />
     <Compile Include="JsonHelper.cs" />
+    <Compile Include="LoginPacketBuilder.cs" />
     <Compile Include="MapleStoryInspector.cs" />
     <Compile Include="NetworkAdapterInstaller.cs" />
     <Compile Include="PortForwardingService.cs" />
+    <Compile Include="PortForwardingProxyWorker.cs" />
     <Compile Include="PortForwardingWorker.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Resource.Designer.cs">

--- a/Aries/Aries.Lib/Aries.Lib.csproj
+++ b/Aries/Aries.Lib/Aries.Lib.csproj
@@ -1,129 +1,35 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{802B66DF-2B10-44C5-8D87-428E26B85F33}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>Aries.Lib</RootNamespace>
+    <TargetFramework>net48</TargetFramework>
     <AssemblyName>Aries.Lib</AssemblyName>
-    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-    <PublishUrl>publish\</PublishUrl>
-    <Install>true</Install>
-    <InstallFrom>Disk</InstallFrom>
-    <UpdateEnabled>false</UpdateEnabled>
-    <UpdateMode>Foreground</UpdateMode>
-    <UpdateInterval>7</UpdateInterval>
-    <UpdateIntervalUnits>Days</UpdateIntervalUnits>
-    <UpdatePeriodically>false</UpdatePeriodically>
-    <UpdateRequired>false</UpdateRequired>
-    <MapFileExtensions>true</MapFileExtensions>
-    <ApplicationRevision>0</ApplicationRevision>
-    <ApplicationVersion>1.0.0.%2a</ApplicationVersion>
-    <IsWebBootstrapper>false</IsWebBootstrapper>
-    <UseApplicationTrust>false</UseApplicationTrust>
-    <BootstrapperEnabled>true</BootstrapperEnabled>
-    <TargetFrameworkProfile />
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
+    <RootNamespace>Aries.Lib</RootNamespace>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <OutputPath>..\..\Aries.out\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>..\..\Aries.out\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
   <PropertyGroup>
-    <SignAssembly>false</SignAssembly>
-  </PropertyGroup>
-  <PropertyGroup>
-    <AssemblyOriginatorKeyFile>
-    </AssemblyOriginatorKeyFile>
-  </PropertyGroup>
-  <PropertyGroup>
-    <DelaySign>false</DelaySign>
+    <LangVersion>7.3</LangVersion>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+    <Reference Include="Newtonsoft.Json">
       <HintPath>..\packages\Newtonsoft.Json.13.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
     <Reference Include="System.Management" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="EncryptUtil.cs" />
-    <Compile Include="FileUtil.cs" />
-    <Compile Include="JsonHelper.cs" />
-    <Compile Include="LoginPacketBuilder.cs" />
-    <Compile Include="MapleStoryInspector.cs" />
-    <Compile Include="NetworkAdapterInstaller.cs" />
-    <Compile Include="PortForwardingService.cs" />
-    <Compile Include="PortForwardingProxyWorker.cs" />
-    <Compile Include="PortForwardingWorker.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="Resource.Designer.cs">
-      <AutoGen>True</AutoGen>
-      <DesignTime>True</DesignTime>
-      <DependentUpon>Resource.resx</DependentUpon>
-    </Compile>
-    <Compile Include="ServerConfigService.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <BootstrapperPackage Include=".NETFramework,Version=v4.5">
-      <Visible>False</Visible>
-      <ProductName>Microsoft .NET Framework 4.5 %28x86 和 x64%29</ProductName>
-      <Install>true</Install>
-    </BootstrapperPackage>
-    <BootstrapperPackage Include="Microsoft.Net.Framework.3.5.SP1">
-      <Visible>False</Visible>
-      <ProductName>.NET Framework 3.5 SP1</ProductName>
-      <Install>false</Install>
-    </BootstrapperPackage>
-  </ItemGroup>
-  <ItemGroup>
-    <EmbeddedResource Include="Resource.resx">
-      <Generator>ResXFileCodeGenerator</Generator>
-      <LastGenOutput>Resource.Designer.cs</LastGenOutput>
+    <EmbeddedResource Include="Resources\devcon_x64.exe">
+      <LogicalName>devcon_x64.exe</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Resources\devcon_x86.exe">
+      <LogicalName>devcon_x86.exe</LogicalName>
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\Aries.Model\Aries.Model.csproj">
-      <Project>{c340bd4e-8e40-4a0c-9dc0-d1fa12fc34ad}</Project>
-      <Name>Aries.Model</Name>
-    </ProjectReference>
+    <ProjectReference Include="..\Aries.Model\Aries.Model.csproj" />
   </ItemGroup>
-  <ItemGroup>
-    <None Include="packages.config" />
-    <None Include="Resources\devcon_x64.exe" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="Resources\devcon_x86.exe" />
-  </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
+  <!-- 构建后 copy to bin for Aries.UI EmbeddedResource reference -->
+  <Target Name="CopyToBin" AfterTargets="Build">
+    <Copy SourceFiles="$(OutputPath)$(AssemblyName).dll" DestinationFolder="$(MSBuildProjectDirectory)\bin\$(Configuration)\net48\" />
   </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
 </Project>

--- a/Aries/Aries.Lib/LoginPacketBuilder.cs
+++ b/Aries/Aries.Lib/LoginPacketBuilder.cs
@@ -1,0 +1,109 @@
+using System;
+using System.Management;
+using System.Text;
+
+namespace Aries.Lib
+{
+    public static class LoginPacketBuilder
+    {
+        private static readonly byte[] EmptyMacAddress = new byte[6];
+
+        public static byte[] Build(string username, string password, Action<string> log)
+        {
+            // 这个包只负责给官方登录页注入 CMS143 账号密码，不扩展其他协议字段。
+            byte[] header = new byte[] { 0x69, 0x69, 0x00, 0x00 };
+            byte[] usernameBytes = Encoding.ASCII.GetBytes(username ?? string.Empty);
+            byte[] usernameLength = ToLittleEndianShort((short)usernameBytes.Length);
+            byte[] passwordBytes = Encoding.ASCII.GetBytes(password ?? string.Empty);
+            byte[] passwordLength = ToLittleEndianShort((short)passwordBytes.Length);
+            byte[] macAddress = GetNetworkAdapterId(log);
+            byte[] reservedMiddle = new byte[15];
+            byte[] reservedAfterUser = new byte[2];
+
+            int payloadLength = macAddress.Length
+                + reservedMiddle.Length
+                + usernameLength.Length
+                + usernameBytes.Length
+                + reservedAfterUser.Length
+                + passwordLength.Length
+                + passwordBytes.Length;
+
+            header[2] = checked((byte)payloadLength);
+
+            byte[] packet = new byte[header.Length + payloadLength];
+            int offset = 0;
+
+            Buffer.BlockCopy(header, 0, packet, offset, header.Length);
+            offset += header.Length;
+            Buffer.BlockCopy(macAddress, 0, packet, offset, macAddress.Length);
+            offset += macAddress.Length;
+            Buffer.BlockCopy(reservedMiddle, 0, packet, offset, reservedMiddle.Length);
+            offset += reservedMiddle.Length;
+            Buffer.BlockCopy(usernameLength, 0, packet, offset, usernameLength.Length);
+            offset += usernameLength.Length;
+            Buffer.BlockCopy(usernameBytes, 0, packet, offset, usernameBytes.Length);
+            offset += usernameBytes.Length;
+            Buffer.BlockCopy(reservedAfterUser, 0, packet, offset, reservedAfterUser.Length);
+            offset += reservedAfterUser.Length;
+            Buffer.BlockCopy(passwordLength, 0, packet, offset, passwordLength.Length);
+            offset += passwordLength.Length;
+            Buffer.BlockCopy(passwordBytes, 0, packet, offset, passwordBytes.Length);
+
+            return packet;
+        }
+
+        private static byte[] GetNetworkAdapterId(Action<string> log)
+        {
+            try
+            {
+                foreach (ManagementObject instance in new ManagementClass("Win32_NetworkAdapterConfiguration").GetInstances())
+                {
+                    object ipEnabledValue = instance["IPEnabled"];
+                    if (!(ipEnabledValue is bool) || !(bool)ipEnabledValue)
+                    {
+                        continue;
+                    }
+
+                    string macAddress = instance["MacAddress"] as string;
+                    if (string.IsNullOrWhiteSpace(macAddress))
+                    {
+                        continue;
+                    }
+
+                    string[] chunks = macAddress.Trim().Split(new[] { ':', '-' }, StringSplitOptions.RemoveEmptyEntries);
+                    if (chunks.Length != EmptyMacAddress.Length)
+                    {
+                        continue;
+                    }
+
+                    byte[] buffer = new byte[EmptyMacAddress.Length];
+                    for (int index = 0; index < buffer.Length; index++)
+                    {
+                        buffer[index] = Convert.ToByte(chunks[index], 16);
+                    }
+
+                    return buffer;
+                }
+
+                log?.Invoke("未找到可用网卡 MAC，登录包按 6 字节零值退化");
+            }
+            catch (Exception ex)
+            {
+                log?.Invoke("读取网卡 MAC 失败，登录包按 6 字节零值退化：" + ex.Message);
+            }
+
+            return (byte[])EmptyMacAddress.Clone();
+        }
+
+        private static byte[] ToLittleEndianShort(short value)
+        {
+            byte[] bytes = BitConverter.GetBytes(value);
+            if (!BitConverter.IsLittleEndian)
+            {
+                Array.Reverse(bytes);
+            }
+
+            return bytes;
+        }
+    }
+}

--- a/Aries/Aries.Lib/PortForwardingProxyWorker.cs
+++ b/Aries/Aries.Lib/PortForwardingProxyWorker.cs
@@ -1,0 +1,221 @@
+using System;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Aries.Lib
+{
+    internal sealed class PortForwardingProxyWorker
+    {
+        private readonly int localPort;
+        private readonly string remoteHost;
+        private readonly int remotePort;
+        private readonly object sessionLock = new object();
+
+        private CancellationTokenSource cancellationTokenSource;
+        private TcpListener listener;
+        private NetworkStream activeUpstreamStream;
+
+        public event WarpMessage WarpMessage;
+
+        public PortForwardingProxyWorker(int localPort, string remoteHost, int remotePort)
+        {
+            this.localPort = localPort;
+            this.remoteHost = remoteHost;
+            this.remotePort = remotePort;
+        }
+
+        public void Start()
+        {
+            if (listener != null)
+            {
+                return;
+            }
+
+            cancellationTokenSource = new CancellationTokenSource();
+            listener = new TcpListener(IPAddress.Any, localPort);
+            listener.Start();
+            SendMessage("登录代理入口已启动 本机:" + localPort + " -> " + remoteHost + ":" + remotePort);
+            Task.Run(() => AcceptLoopAsync(cancellationTokenSource.Token));
+        }
+
+        public void Stop()
+        {
+            try
+            {
+                cancellationTokenSource?.Cancel();
+                listener?.Stop();
+            }
+            catch
+            {
+            }
+            finally
+            {
+                listener = null;
+                ClearSession();
+            }
+        }
+
+        public bool TrySendPacket(byte[] packet)
+        {
+            if (packet == null || packet.Length == 0)
+            {
+                SendErrorMessage("登录包为空，sendPacket 已拒绝");
+                return false;
+            }
+
+            NetworkStream stream;
+            lock (sessionLock)
+            {
+                stream = activeUpstreamStream;
+            }
+
+            if (stream == null)
+            {
+                SendErrorMessage("请在客户端进入到官方登录页面后再点击登陆");
+                return false;
+            }
+
+            try
+            {
+                stream.Write(packet, 0, packet.Length);
+                stream.Flush();
+                SendMessage("登录包已注入 " + packet.Length + " bytes");
+                return true;
+            }
+            catch (Exception ex)
+            {
+                SendErrorMessage("登录包注入失败：" + ex.Message);
+                ClearSession();
+                return false;
+            }
+        }
+
+        private async Task AcceptLoopAsync(CancellationToken token)
+        {
+            while (!token.IsCancellationRequested)
+            {
+                TcpClient downstream = null;
+                try
+                {
+                    downstream = await listener.AcceptTcpClientAsync();
+                    Task ignored = Task.Run(() => HandleClientAsync(downstream, token));
+                }
+                catch (ObjectDisposedException)
+                {
+                    break;
+                }
+                catch (InvalidOperationException)
+                {
+                    break;
+                }
+                catch (Exception ex)
+                {
+                    if (!token.IsCancellationRequested)
+                    {
+                        SendErrorMessage("登录代理监听失败：" + ex.Message);
+                    }
+
+                    downstream?.Close();
+                    break;
+                }
+            }
+        }
+
+        private async Task HandleClientAsync(TcpClient downstream, CancellationToken token)
+        {
+            using (downstream)
+            using (TcpClient upstream = new TcpClient())
+            {
+                try
+                {
+                    await upstream.ConnectAsync(remoteHost, remotePort);
+                    SetSession(upstream.GetStream());
+                    Task uplink = PumpAsync(downstream.GetStream(), upstream.GetStream(), token);
+                    Task downlink = PumpAsync(upstream.GetStream(), downstream.GetStream(), token);
+                    await Task.WhenAny(uplink, downlink);
+                }
+                catch (Exception ex)
+                {
+                    if (!token.IsCancellationRequested)
+                    {
+                        SendErrorMessage("登录代理链路失败：" + ex.Message);
+                    }
+                }
+                finally
+                {
+                    ClearSession();
+                }
+            }
+        }
+
+        private static async Task PumpAsync(NetworkStream input, NetworkStream output, CancellationToken token)
+        {
+            byte[] buffer = new byte[4096];
+
+            while (!token.IsCancellationRequested)
+            {
+                int read;
+                try
+                {
+                    read = await input.ReadAsync(buffer, 0, buffer.Length, token);
+                }
+                catch
+                {
+                    break;
+                }
+
+                if (read <= 0)
+                {
+                    break;
+                }
+
+                try
+                {
+                    await output.WriteAsync(buffer, 0, read, token);
+                    output.Flush();
+                }
+                catch
+                {
+                    break;
+                }
+            }
+        }
+
+        private void SetSession(NetworkStream upstreamStream)
+        {
+            lock (sessionLock)
+            {
+                activeUpstreamStream = upstreamStream;
+            }
+
+            SendMessage("登录代理会话已建立");
+        }
+
+        private void ClearSession()
+        {
+            bool hadSession;
+            lock (sessionLock)
+            {
+                hadSession = activeUpstreamStream != null;
+                activeUpstreamStream = null;
+            }
+
+            if (hadSession)
+            {
+                SendMessage("登录代理会话已关闭");
+            }
+        }
+
+        private void SendMessage(string message)
+        {
+            WarpMessage?.Invoke(MessageType.Tips, message);
+        }
+
+        private void SendErrorMessage(string message)
+        {
+            WarpMessage?.Invoke(MessageType.Error, message);
+        }
+    }
+}

--- a/Aries/Aries.Lib/PortForwardingService.cs
+++ b/Aries/Aries.Lib/PortForwardingService.cs
@@ -12,6 +12,7 @@ namespace Aries.Lib
         public WarpMessage WarpMessage;
 
         private Dictionary<int, PortForwardingWorker> workers;
+        private PortForwardingProxyWorker loginWorker;
 
         public PortForwardingService()
         {
@@ -25,7 +26,10 @@ namespace Aries.Lib
             await Task.Run(() =>
             {
                 SendMessage("正在开启端口映射...");
-                int count = 0;
+                if (loginWorker != null)
+                {
+                    loginWorker.Start();
+                }
                 foreach (PortForwardingWorker worker in workers.Values)
                 {
                     if (!worker.IsRunning)
@@ -34,15 +38,6 @@ namespace Aries.Lib
                     }
                 }
                 callback(true);
-                //if (count > 0)
-                //{
-                //    Stop();
-                //    callback(false);
-                //}
-                //else
-                //{
-                //    callback(true);
-                //}
             });
 
         }
@@ -62,6 +57,12 @@ namespace Aries.Lib
                 }
             }
             workers.Clear();
+
+            if (loginWorker != null)
+            {
+                loginWorker.Stop();
+                loginWorker = null;
+            }
             SendMessage("端口映射已停止");
         }
 
@@ -80,6 +81,27 @@ namespace Aries.Lib
             }
         }
 
+        public void SetLoginForwarding(int localPort, string host, int port)
+        {
+            if (loginWorker != null)
+            {
+                loginWorker.Stop();
+            }
+
+            loginWorker = new PortForwardingProxyWorker(localPort, host, port);
+            loginWorker.WarpMessage += ForwardLoginWorkerMessage;
+        }
+
+        public bool sendPacket(byte[] packet)
+        {
+            if (loginWorker == null)
+            {
+                SendErrorMessage("登录代理尚未初始化，请先点击启动");
+                return false;
+            }
+
+            return loginWorker.TrySendPacket(packet);
+        }
 
         #endregion
 
@@ -101,6 +123,16 @@ namespace Aries.Lib
             WarpMessage?.Invoke(MessageType.Error, Msg);
         }
 
+        private void ForwardLoginWorkerMessage(MessageType type, string message)
+        {
+            if (type == MessageType.Tips)
+            {
+                SendMessage(message);
+                return;
+            }
+
+            SendErrorMessage(message);
+        }
 
     }
 }

--- a/Aries/Aries.Lib/ServerConfigService.cs
+++ b/Aries/Aries.Lib/ServerConfigService.cs
@@ -35,6 +35,7 @@ namespace Aries.Lib
         public static WarpMessage WarpMessage;
         public static readonly string ARIESDIR = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments) + @"\Aries\";
         public static readonly string FILE = ARIESDIR + @"Aries.json";
+        private static UserConfig userConfig = new UserConfig();
         static string LoadFile()
         {
             try
@@ -66,7 +67,8 @@ namespace Aries.Lib
             },
                 lastId = 0,
                 mode = 0,
-                quickPass = true
+                quickPass = true,
+                user = new UserConfig()
             });
         }
 
@@ -79,11 +81,12 @@ namespace Aries.Lib
         {
             if (serverConfigs == null)
             {
-                var config = new { mode = 0,lastId = 0, quickPass = true, configs = new ServerConfig[0] };
+                var config = new { mode = 0,lastId = 0, quickPass = true, configs = new ServerConfig[0], user = new UserConfig() };
                 config = JsonHelper.DeserializeAnonymousType(LoadFile(), config);
                 LastId = config.lastId;
                 Mode = (NetForwardMode)config.mode;
                 QuickPass = config.quickPass;
+                userConfig = NormalizeUser(config.user);
 
                 var q = from c in config.configs
                         select c;
@@ -93,8 +96,30 @@ namespace Aries.Lib
             return serverConfigs;
         }
 
+        public static UserConfig LoadUser()
+        {
+            EnsureLoaded();
+            return new UserConfig
+            {
+                Username = userConfig.Username,
+                Password = userConfig.Password
+            };
+        }
+
+        public static void SaveUser(string username, string password)
+        {
+            EnsureLoaded();
+            userConfig = new UserConfig
+            {
+                Username = username ?? string.Empty,
+                Password = password ?? string.Empty
+            };
+            SaveAll();
+        }
+
         public static void SaveAll()
         {
+            EnsureLoaded();
             if (!Directory.Exists(ARIESDIR))
             {
                 Directory.CreateDirectory(ARIESDIR);
@@ -102,18 +127,19 @@ namespace Aries.Lib
 
             using (var writer = new StreamWriter(FILE))
             {
-                writer.Write(JsonHelper.SerializeObject(new { configs = serverConfigs, lastId = LastId,mode = Mode, quickPass=QuickPass }));
+                writer.Write(JsonHelper.SerializeObject(new { configs = serverConfigs, lastId = LastId,mode = Mode, quickPass=QuickPass, user = userConfig }));
             }
 
         }
 
         public static void SaveOrUpdateInMemory(ServerConfig serverConfig)
         {
+            EnsureLoaded();
             if (serverConfig.ID == 0)
             {
                 var q = from sc in serverConfigs
                         select sc.ID;
-                serverConfig.ID = q.Max() + 1;
+                serverConfig.ID = q.Any() ? q.Max() + 1 : 1;
                 serverConfigs.Add(serverConfig);
             }
             else
@@ -127,7 +153,30 @@ namespace Aries.Lib
 
         public static bool RemoveFromMemory(ServerConfig serverConfig)
         {
+            EnsureLoaded();
             return serverConfigs.Remove(serverConfig);
+        }
+
+        private static void EnsureLoaded()
+        {
+            if (serverConfigs == null)
+            {
+                LoadAll();
+            }
+        }
+
+        private static UserConfig NormalizeUser(UserConfig user)
+        {
+            if (user == null)
+            {
+                return new UserConfig();
+            }
+
+            return new UserConfig
+            {
+                Username = user.Username ?? string.Empty,
+                Password = user.Password ?? string.Empty
+            };
         }
 
     }

--- a/Aries/Aries.Model/Aries.Model.csproj
+++ b/Aries/Aries.Model/Aries.Model.csproj
@@ -1,71 +1,23 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{C340BD4E-8E40-4A0C-9DC0-D1FA12FC34AD}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>Aries.Model</RootNamespace>
+    <TargetFramework>net48</TargetFramework>
     <AssemblyName>Aries.Model</AssemblyName>
-    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-    <TargetFrameworkProfile />
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
+    <RootNamespace>Aries.Model</RootNamespace>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <OutputPath>..\..\Aries.out\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>..\..\Aries.out\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
   <PropertyGroup>
-    <SignAssembly>false</SignAssembly>
-  </PropertyGroup>
-  <PropertyGroup>
-    <AssemblyOriginatorKeyFile>
-    </AssemblyOriginatorKeyFile>
+    <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+    <Reference Include="Newtonsoft.Json">
       <HintPath>..\packages\Newtonsoft.Json.13.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="System" />
     <Reference Include="System.ComponentModel.DataAnnotations" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Xml" />
   </ItemGroup>
-  <ItemGroup>
-    <Compile Include="ObservableObject.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="ServerConfig.cs" />
-    <Compile Include="UserConfig.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="packages.config" />
-  </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
+  <!-- 构建后 copy to bin for Aries.UI EmbeddedResource reference -->
+  <Target Name="CopyToBin" AfterTargets="Build">
+    <Copy SourceFiles="$(OutputPath)$(AssemblyName).dll" DestinationFolder="$(MSBuildProjectDirectory)\bin\$(Configuration)\net48\" />
   </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
 </Project>

--- a/Aries/Aries.Model/Aries.Model.csproj
+++ b/Aries/Aries.Model/Aries.Model.csproj
@@ -55,6 +55,7 @@
     <Compile Include="ObservableObject.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ServerConfig.cs" />
+    <Compile Include="UserConfig.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/Aries/Aries.Model/UserConfig.cs
+++ b/Aries/Aries.Model/UserConfig.cs
@@ -1,0 +1,15 @@
+namespace Aries.Model
+{
+    public class UserConfig
+    {
+        public UserConfig()
+        {
+            Username = string.Empty;
+            Password = string.Empty;
+        }
+
+        public string Username { get; set; }
+
+        public string Password { get; set; }
+    }
+}

--- a/Aries/Aries.UI/App.xaml.cs
+++ b/Aries/Aries.UI/App.xaml.cs
@@ -16,6 +16,12 @@ namespace Aries
     /// </summary>
     public partial class App : Application
     {
+        /// <summary>静态构造 — 在 InitializeComponent 前注册 AssemblyResolve，避免 BAML 资源加载时找不到内嵌 DLL</summary>
+        static App()
+        {
+            AppDomain.CurrentDomain.AssemblyResolve += OnResolveAssembly;
+        }
+
         private static Assembly OnResolveAssembly(object sender, ResolveEventArgs args)
         {
             Assembly executingAssembly = Assembly.GetExecutingAssembly();
@@ -50,7 +56,6 @@ namespace Aries
         protected override void OnStartup(StartupEventArgs e)
         {
             base.OnStartup(e);
-            AppDomain.CurrentDomain.AssemblyResolve += OnResolveAssembly;
         }
     }
 }

--- a/Aries/Aries.UI/Aries.UI.csproj
+++ b/Aries/Aries.UI/Aries.UI.csproj
@@ -1,202 +1,84 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{0F56EDA9-CF7F-4C49-A67B-3FCD434D4902}</ProjectGuid>
-    <OutputType>WinExe</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>Aries</RootNamespace>
+    <TargetFramework>net48</TargetFramework>
     <AssemblyName>Aries</AssemblyName>
-    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-    <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <WarningLevel>4</WarningLevel>
-    <TargetFrameworkProfile />
-    <PublishUrl>publish\</PublishUrl>
-    <Install>true</Install>
-    <InstallFrom>Disk</InstallFrom>
-    <UpdateEnabled>false</UpdateEnabled>
-    <UpdateMode>Foreground</UpdateMode>
-    <UpdateInterval>7</UpdateInterval>
-    <UpdateIntervalUnits>Days</UpdateIntervalUnits>
-    <UpdatePeriodically>false</UpdatePeriodically>
-    <UpdateRequired>false</UpdateRequired>
-    <MapFileExtensions>true</MapFileExtensions>
-    <ApplicationRevision>0</ApplicationRevision>
-    <ApplicationVersion>1.0.0.%2a</ApplicationVersion>
-    <IsWebBootstrapper>false</IsWebBootstrapper>
-    <UseApplicationTrust>false</UseApplicationTrust>
-    <BootstrapperEnabled>true</BootstrapperEnabled>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
+    <RootNamespace>Aries</RootNamespace>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <OutputType>WinExe</OutputType>
+    <UseWPF>true</UseWPF>
     <OutputPath>..\..\Aries.out\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>..\..\Aries.out\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
   <PropertyGroup>
-    <StartupObject>
-    </StartupObject>
-  </PropertyGroup>
-  <PropertyGroup>
+    <LangVersion>latest</LangVersion>
     <ApplicationIcon>BlueSnail.ico</ApplicationIcon>
-  </PropertyGroup>
-  <PropertyGroup />
-  <PropertyGroup>
-    <TargetZone>LocalIntranet</TargetZone>
-  </PropertyGroup>
-  <PropertyGroup>
-    <GenerateManifests>false</GenerateManifests>
-  </PropertyGroup>
-  <PropertyGroup>
     <ApplicationManifest>Properties\app.manifest</ApplicationManifest>
   </PropertyGroup>
+
+  <!-- NuGet 引用 -->
   <ItemGroup>
-    <Reference Include="ControlzEx, Version=3.0.2.4, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="ControlzEx">
       <HintPath>..\packages\ControlzEx.3.0.2.4\lib\net462\ControlzEx.dll</HintPath>
     </Reference>
-    <Reference Include="MahApps.Metro, Version=1.6.5.1, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="MahApps.Metro">
       <HintPath>..\packages\MahApps.Metro.1.6.5\lib\net47\MahApps.Metro.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Xaml.Behaviors, Version=1.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="Microsoft.Xaml.Behaviors">
       <HintPath>..\packages\Microsoft.Xaml.Behaviors.Wpf.1.1.39\lib\net45\Microsoft.Xaml.Behaviors.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+    <Reference Include="Newtonsoft.Json">
       <HintPath>..\packages\Newtonsoft.Json.13.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="System" />
-    <Reference Include="System.ComponentModel.DataAnnotations" />
-    <Reference Include="System.Configuration" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Drawing" />
-    <Reference Include="System.Web" />
-    <Reference Include="System.Web.Extensions" />
-    <Reference Include="System.Windows.Forms" />
-    <Reference Include="System.Windows.Interactivity, Version=4.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+    <Reference Include="System.Windows.Interactivity">
       <HintPath>..\packages\ControlzEx.3.0.2.4\lib\net462\System.Windows.Interactivity.dll</HintPath>
     </Reference>
-    <Reference Include="System.Xml" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="System.Xaml">
-      <RequiredTargetFramework>4.0</RequiredTargetFramework>
-    </Reference>
-    <Reference Include="WindowsBase" />
-    <Reference Include="PresentationCore" />
-    <Reference Include="PresentationFramework" />
   </ItemGroup>
+
+  <!-- 项目引用 -->
   <ItemGroup>
-    <ApplicationDefinition Include="App.xaml">
-      <Generator>MSBuild:Compile</Generator>
-      <SubType>Designer</SubType>
-    </ApplicationDefinition>
-    <Page Include="AriesAbout.xaml">
-      <SubType>Designer</SubType>
-      <Generator>MSBuild:Compile</Generator>
-    </Page>
-    <Page Include="EditServerConfigWindow.xaml">
-      <SubType>Designer</SubType>
-      <Generator>MSBuild:Compile</Generator>
-    </Page>
-    <Page Include="MainWindow.xaml">
-      <Generator>MSBuild:Compile</Generator>
-      <SubType>Designer</SubType>
-    </Page>
-    <Compile Include="App.xaml.cs">
-      <DependentUpon>App.xaml</DependentUpon>
-      <SubType>Code</SubType>
-    </Compile>
-    <Compile Include="AriesAbout.xaml.cs">
-      <DependentUpon>AriesAbout.xaml</DependentUpon>
-    </Compile>
-    <Compile Include="Converters\MultiConverter.cs" />
-    <Compile Include="EditServerConfigWindow.xaml.cs">
-      <DependentUpon>EditServerConfigWindow.xaml</DependentUpon>
-    </Compile>
-    <Compile Include="MainWindow.xaml.cs">
-      <DependentUpon>MainWindow.xaml</DependentUpon>
-      <SubType>Code</SubType>
-    </Compile>
-    <Page Include="Styles\MainStyle.xaml">
-      <SubType>Designer</SubType>
-      <Generator>MSBuild:Compile</Generator>
-    </Page>
+    <ProjectReference Include="..\Aries.Lib\Aries.Lib.csproj">
+      <Private>false</Private>
+    </ProjectReference>
+    <ProjectReference Include="..\Aries.Model\Aries.Model.csproj">
+      <Private>false</Private>
+    </ProjectReference>
   </ItemGroup>
+
+  <!-- Embed DLL resources for AssemblyResolve -->
   <ItemGroup>
-    <Compile Include="Converters\NullToFalseConverter.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs">
-      <SubType>Code</SubType>
-    </Compile>
-    <Compile Include="Properties\Resources.Designer.cs">
-      <AutoGen>True</AutoGen>
-      <DesignTime>True</DesignTime>
-      <DependentUpon>Resources.resx</DependentUpon>
-    </Compile>
-    <Compile Include="Properties\Settings.Designer.cs">
-      <AutoGen>True</AutoGen>
-      <DependentUpon>Settings.settings</DependentUpon>
-      <DesignTimeSharedInput>True</DesignTimeSharedInput>
-    </Compile>
-    <EmbeddedResource Include="Properties\Resources.resx">
-      <Generator>ResXFileCodeGenerator</Generator>
-      <LastGenOutput>Resources.Designer.cs</LastGenOutput>
+    <EmbeddedResource Include="..\Aries.Lib\bin\$(Configuration)\net48\Aries.Lib.dll">
+      <LogicalName>Aries.Lib.dll</LogicalName>
     </EmbeddedResource>
-    <None Include="packages.config" />
-    <None Include="Properties\app.manifest" />
-    <None Include="Properties\Settings.settings">
-      <Generator>SettingsSingleFileGenerator</Generator>
-      <LastGenOutput>Settings.Designer.cs</LastGenOutput>
-    </None>
-    <AppDesigner Include="Properties\" />
+    <EmbeddedResource Include="..\Aries.Model\bin\$(Configuration)\net48\Aries.Model.dll">
+      <LogicalName>Aries.Model.dll</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="..\packages\MahApps.Metro.1.6.5\lib\net47\MahApps.Metro.dll">
+      <LogicalName>MahApps.Metro.dll</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="..\packages\ControlzEx.3.0.2.4\lib\net462\ControlzEx.dll">
+      <LogicalName>ControlzEx.dll</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="..\packages\Newtonsoft.Json.13.0.2\lib\net45\Newtonsoft.Json.dll">
+      <LogicalName>Newtonsoft.Json.dll</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="..\packages\ControlzEx.3.0.2.4\lib\net462\System.Windows.Interactivity.dll">
+      <LogicalName>System.Windows.Interactivity.dll</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="..\packages\Microsoft.Xaml.Behaviors.Wpf.1.1.39\lib\net45\Microsoft.Xaml.Behaviors.dll">
+      <LogicalName>Microsoft.Xaml.Behaviors.dll</LogicalName>
+    </EmbeddedResource>
   </ItemGroup>
+
+  <!-- 其他文件 -->
   <ItemGroup>
     <None Include="App.config" />
   </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\Aries.Lib\Aries.Lib.csproj">
-      <Project>{802b66df-2b10-44c5-8d87-428e26b85f33}</Project>
-      <Name>Aries.Lib</Name>
-      <Private>False</Private>
-    </ProjectReference>
-    <ProjectReference Include="..\Aries.Model\Aries.Model.csproj">
-      <Project>{c340bd4e-8e40-4a0c-9dc0-d1fa12fc34ad}</Project>
-      <Name>Aries.Model</Name>
-      <Private>False</Private>
-    </ProjectReference>
-  </ItemGroup>
-  <ItemGroup>
-    <Resource Include="BlueSnail.ico" />
-  </ItemGroup>
-  <ItemGroup>
-    <BootstrapperPackage Include="Microsoft.Net.Framework.3.5.SP1">
-      <Visible>False</Visible>
-      <ProductName>.NET Framework 3.5 SP1</ProductName>
-      <Install>false</Install>
-    </BootstrapperPackage>
-  </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
+
+  <!-- 构建后清除非 EXE 侧车 -->
+  <Target Name="StripSidecar" AfterTargets="Build">
+    <ItemGroup>
+      <Sidecars Include="$(OutputPath)*.dll;$(OutputPath)*.xml" />
+    </ItemGroup>
+    <Delete Files="@(Sidecars)" />
   </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
 </Project>

--- a/Aries/Aries.UI/Aries.UI.csproj
+++ b/Aries/Aries.UI/Aries.UI.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <LangVersion>latest</LangVersion>
-    <ApplicationIcon>BlueSnail.ico</ApplicationIcon>
+    <ApplicationIcon>bluesnail.ico</ApplicationIcon>
     <ApplicationManifest>Properties\app.manifest</ApplicationManifest>
   </PropertyGroup>
 
@@ -69,8 +69,9 @@
     </EmbeddedResource>
   </ItemGroup>
 
-  <!-- 其他文件 -->
+  <!-- 资源文件 -->
   <ItemGroup>
+    <Resource Include="bluesnail.ico" />
     <None Include="App.config" />
   </ItemGroup>
 

--- a/Aries/Aries.UI/Converters/BooleanToVisibilityConverter.cs
+++ b/Aries/Aries.UI/Converters/BooleanToVisibilityConverter.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Windows;
+using System.Windows.Data;
+
+namespace Aries.Converters
+{
+    /// <summary>
+    /// bool → Visibility 转换器：true=Visible, false=Collapsed
+    /// </summary>
+    public sealed class BooleanToVisibilityConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+        {
+            return (value is bool b && b) ? Visibility.Visible : Visibility.Collapsed;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+        {
+            return value is Visibility v && v == Visibility.Visible;
+        }
+    }
+}

--- a/Aries/Aries.UI/EditServerConfigWindow.xaml
+++ b/Aries/Aries.UI/EditServerConfigWindow.xaml
@@ -5,7 +5,7 @@
                       xmlns:Model="clr-namespace:Aries.Model;assembly=Aries.Model" x:Class="Aries.EditServerConfigWindow"
                       Title="编辑服务器配置信息"
                       Height="280"
-                      Width="480" ResizeMode="NoResize" Icon="BlueSnail.ico" WindowStartupLocation="CenterOwner">
+                      Width="480" ResizeMode="NoResize" Icon="bluesnail.ico" WindowStartupLocation="CenterOwner">
     <Grid>
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="209*"/>

--- a/Aries/Aries.UI/MainWindow.xaml
+++ b/Aries/Aries.UI/MainWindow.xaml
@@ -106,6 +106,20 @@
 
 
             </StackPanel>
+            <StackPanel Style="{StaticResource RowStyle}" HorizontalAlignment="Center">
+                <StackPanel Margin="20,0,20,0">
+                    <StackPanel Style="{StaticResource RowStyle}">
+                        <Label Style="{StaticResource SubLabelStyle2}" Content="输入账号"/>
+                        <TextBox x:Name="tbUsername" TextWrapping="Wrap" Margin="5" Height="30" Width="200"/>
+                    </StackPanel>
+                    <StackPanel Style="{StaticResource RowStyle}">
+                        <Label Style="{StaticResource SubLabelStyle2}" Content="输入密码"/>
+                        <PasswordBox x:Name="pbPassword" Margin="5" Height="30" Width="200"/>
+                    </StackPanel>
+                    <CheckBox x:Name="checkRememberUser" Content="记住账号和密码" Margin="75,0,0,0" Unchecked="checkRememberUser_Unchecked"/>
+                </StackPanel>
+                <Button x:Name="btnLogin" Content="登陆" Style="{StaticResource ButtonLgStyle}" Height="57" Width="75" Margin="0,0,40,0" Click="btnLogin_Click"/>
+            </StackPanel>
             <TextBox x:Name="tbLogs" TextWrapping="Wrap" Margin="5" Text="{Binding DataContext, RelativeSource={RelativeSource Self}}" Height="100"/>
         </StackPanel>
     </Grid>

--- a/Aries/Aries.UI/MainWindow.xaml
+++ b/Aries/Aries.UI/MainWindow.xaml
@@ -8,6 +8,7 @@
                       Width="480" Icon="BlueSnail.ico" ResizeMode="NoResize" Closed="MetroWindow_Closed" SizeToContent="Height" Closing="MetroWindow_Closing" WindowStartupLocation="CenterScreen">
     <Controls:MetroWindow.Resources>
         <localConverters:NullToFalseConverter x:Key="NullToFalseConverter"/>
+        <localConverters:BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter"/>
     </Controls:MetroWindow.Resources>
 
     <Controls:MetroWindow.RightWindowCommands>
@@ -102,11 +103,19 @@
                             </StackPanel>
                         </CheckBox.ToolTip>
                     </CheckBox>
+                    <CheckBox x:Name="checkSpecialMode" Content="特殊模式(支持CMS143)" Margin="5" Checked="checkSpecialMode_Checked" Unchecked="checkSpecialMode_Unchecked" >
+                        <CheckBox.ToolTip>
+                            <StackPanel>
+                                <Label Content="勾选后启动时将使用登录代理注入账号密码，支持 CMS143 等需要特殊登录包的版本">
+                                </Label>
+                            </StackPanel>
+                        </CheckBox.ToolTip>
+                    </CheckBox>
                 </StackPanel>
 
 
             </StackPanel>
-            <StackPanel Style="{StaticResource RowStyle}" HorizontalAlignment="Center">
+            <StackPanel x:Name="SpecialLoginPanel" Style="{StaticResource RowStyle}" HorizontalAlignment="Center" Visibility="Collapsed">
                 <StackPanel Margin="20,0,20,0">
                     <StackPanel Style="{StaticResource RowStyle}">
                         <Label Style="{StaticResource SubLabelStyle2}" Content="输入账号"/>

--- a/Aries/Aries.UI/MainWindow.xaml
+++ b/Aries/Aries.UI/MainWindow.xaml
@@ -5,7 +5,7 @@
                       xmlns:d="http://schemas.microsoft.com/expression/blend/2008" xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" mc:Ignorable="d" x:Class="Aries.MainWindow"
                       xmlns:localConverters="clr-namespace:Aries.Converters"                  
                       Title="MapleStory登录器"
-                      Width="480" Icon="BlueSnail.ico" ResizeMode="NoResize" Closed="MetroWindow_Closed" SizeToContent="Height" Closing="MetroWindow_Closing" WindowStartupLocation="CenterScreen">
+                      Width="480" Icon="bluesnail.ico" ResizeMode="NoResize" Closed="MetroWindow_Closed" SizeToContent="Height" Closing="MetroWindow_Closing" WindowStartupLocation="CenterScreen">
     <Controls:MetroWindow.Resources>
         <localConverters:NullToFalseConverter x:Key="NullToFalseConverter"/>
         <localConverters:BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter"/>

--- a/Aries/Aries.UI/MainWindow.xaml.cs
+++ b/Aries/Aries.UI/MainWindow.xaml.cs
@@ -352,5 +352,17 @@ namespace Aries
             checkRememberUser.IsChecked = false;
             ServerConfigService.SaveUser(string.Empty, string.Empty);
         }
+
+        /// <summary>勾选"特殊模式(支持CMS143)" → 展开登录凭据面板</summary>
+        private void checkSpecialMode_Checked(object sender, RoutedEventArgs e)
+        {
+            SpecialLoginPanel.Visibility = Visibility.Visible;
+        }
+
+        /// <summary>取消"特殊模式" → 隐藏登录凭据面板</summary>
+        private void checkSpecialMode_Unchecked(object sender, RoutedEventArgs e)
+        {
+            SpecialLoginPanel.Visibility = Visibility.Collapsed;
+        }
     }
 }

--- a/Aries/Aries.UI/MainWindow.xaml.cs
+++ b/Aries/Aries.UI/MainWindow.xaml.cs
@@ -17,6 +17,7 @@ namespace Aries
         BindingList<ServerConfig> serverConfigs;
 
         public MapleStoryInspector inspector;
+        public UserConfig user;
 
         public PortForwardingService portService;
 
@@ -44,6 +45,14 @@ namespace Aries
             cbServerConfig.DataContext = serverConfigs;
 
             cbServerConfig.SelectedValue = ServerConfigService.LastId;
+
+            user = ServerConfigService.LoadUser();
+            if (user != null && !string.IsNullOrEmpty(user.Username))
+            {
+                tbUsername.Text = user.Username;
+                pbPassword.Password = user.Password ?? string.Empty;
+                checkRememberUser.IsChecked = true;
+            }
         }
 
         private void InitMapleInspector()
@@ -89,12 +98,14 @@ namespace Aries
                 if (success)
                 {
                     ServerConfig cfg = serverConfigs[Convert.ToInt32(cbServerConfig.SelectedIndex)];
+                    portService.Stop();
                     if (cfg.Host == "localhost" || cfg.Host == "127.0.0.1")
                     {
                         LauchMaple(success);
                         return;
                     }
-                    portService.AddForwarding(8484, cfg.Host, cfg.LoginPort);
+                    // 保持原版客户端固定连 221.231.130.70:8484，只把 8484 映射替换成可注入登录包的代理会话。
+                    portService.SetLoginForwarding(8484, cfg.Host, cfg.LoginPort);
                     portService.AddForwarding(8600, cfg.Host, cfg.ShopPort);
                     portService.AddForwarding(8700, cfg.Host, cfg.AhPort);
                     portService.AddForwarding(8283, cfg.Host, cfg.ChatPort);
@@ -166,6 +177,34 @@ namespace Aries
                 NetworkAdapterInstaller.CheckAndInstallAdapter(LaunchForwarding);
             }
 
+        }
+
+        private void btnLogin_Click(object sender, RoutedEventArgs e)
+        {
+            string username = tbUsername.Text == null ? string.Empty : tbUsername.Text.Trim();
+            string password = pbPassword.Password ?? string.Empty;
+            if (string.IsNullOrEmpty(username) || username.Length < 6)
+            {
+                tbLogs.Text += "[错误]账号长度需大于等于6\n";
+                return;
+            }
+
+            if (string.IsNullOrEmpty(password) || password.Length < 6)
+            {
+                tbLogs.Text += "[错误]密码长度需大于等于6\n";
+                return;
+            }
+
+            if (checkRememberUser.IsChecked == true)
+            {
+                ServerConfigService.SaveUser(username, password);
+            }
+            else
+            {
+                ServerConfigService.SaveUser(string.Empty, string.Empty);
+            }
+
+            portService.sendPacket(LoginPacketBuilder.Build(username, password, message => WarpMessage(MessageType.Tips, message)));
         }
 
         private void radio_Adapter_Checked(object sender, RoutedEventArgs e)
@@ -306,6 +345,12 @@ namespace Aries
         {
             ServerConfigService.QuickPass = (bool)checkQuickPass.IsChecked;
             inspector.QuickPass = ServerConfigService.QuickPass;
+        }
+
+        private void checkRememberUser_Unchecked(object sender, RoutedEventArgs e)
+        {
+            checkRememberUser.IsChecked = false;
+            ServerConfigService.SaveUser(string.Empty, string.Empty);
         }
     }
 }


### PR DESCRIPTION
## What Changed
- 新增 CMS143 登录包构建器（LoginPacketBuilder），注入账号密码凭据到登录流程
- 新增 PortForwardingProxyWorker，将原 8484 登录转发替换为会话感知代理，登录包注入活跃 8484 上游
- 新增 UserConfig 凭据持久化（账号/密码/记住我）
- 新增特殊模式复选框，勾选展开 CMS143 凭据面板，取消折叠
- 新增 BooleanToVisibilityConverter 支持 UI 状态切换

## Why
CMS143 版本已实机验证。核心约束：保留原始 Aries 网络拓扑，仅嫁接 CMS143 最小登录模块。

## Validation
- dotnet build Aries.sln -c Release：0 警告 0 错误
- 本地 GUI 启动正常，特殊模式复选框显隐逻辑正确
- 产物单文件 Aries.exe（DLL 内嵌）

## Scope Notice
- 仅 CMS143 测试通过，其他版本未测试